### PR TITLE
Extract custom widget injection and harden Add Widget menu matching

### DIFF
--- a/public/content-scripts/dashboard-widget-utils.js
+++ b/public/content-scripts/dashboard-widget-utils.js
@@ -1,0 +1,239 @@
+(function () {
+  'use strict';
+
+  const GLOBAL_NAME = 'ActualBudgetTweaksDashboardWidgets';
+  const CUSTOM_WIDGET_ATTR = 'data-abt-custom-dashboard-widget';
+  const MENU_SELECTOR = '[data-popover]';
+  const ADD_WIDGET_MENU_KEYS = [
+    'cash-flow-card',
+    'net-worth-card',
+    'markdown-card',
+    'custom-report',
+  ];
+  const MENU_ITEM_HOVER_BACKGROUND =
+    'var(--color-menuItemBackgroundHover, var(--color-buttonBareBackgroundHover, rgba(200, 200, 200, .25)))';
+  const MENU_ITEM_HOVER_TEXT =
+    'var(--color-menuItemTextHover, var(--color-buttonBareTextHover, inherit))';
+
+  if (window[GLOBAL_NAME]) return;
+
+  function parseMeta(meta) {
+    if (!meta) return {};
+    if (typeof meta === 'string') {
+      try { return JSON.parse(meta) || {}; } catch { return {}; }
+    }
+    return meta;
+  }
+
+  function createMarkdownWidgetDefinition({
+    key,
+    label,
+    placeholderText,
+    width,
+    height,
+    meta = {},
+  }) {
+    return {
+      key,
+      label,
+      matchesRecord(widget) {
+        const widgetMeta = parseMeta(widget?.meta);
+        return widget?.type === 'markdown-card' &&
+          String(widgetMeta.content || '').includes(placeholderText);
+      },
+      buildWidgetPayload(dashboardPageId) {
+        return {
+          type: 'markdown-card',
+          width,
+          height,
+          meta: {
+            ...meta,
+            content: placeholderText,
+            name: label,
+          },
+          dashboard_page_id: dashboardPageId,
+        };
+      },
+    };
+  }
+
+  function getReactFiber(element) {
+    const key = Object.keys(element).find(name =>
+      name.startsWith('__reactFiber$') ||
+      name.startsWith('__reactInternalInstance$')
+    );
+    return key ? element[key] : null;
+  }
+
+  function normalizeReactKey(key) {
+    if (typeof key !== 'string') return null;
+    return key.replace(/^\.\$/, '').replace(/^\$/, '');
+  }
+
+  // Actual's Menu does not expose item names as DOM attributes. Its buttons are
+  // keyed by item.name, which lets this avoid matching localized text labels.
+  function getNativeMenuItemName(button) {
+    let fiber = getReactFiber(button);
+    while (fiber) {
+      const key = normalizeReactKey(fiber.key);
+      if (key) return key;
+      fiber = fiber.return;
+    }
+    return null;
+  }
+
+  function isVisibleButton(button) {
+    const style = window.getComputedStyle?.(button);
+    return !button.disabled &&
+      style?.display !== 'none' &&
+      style?.visibility !== 'hidden';
+  }
+
+  function getMenuButtons(menu) {
+    return Array.from(menu.querySelectorAll('button')).filter(isVisibleButton);
+  }
+
+  function getButtonByMenuItemName(menu, itemName) {
+    return getMenuButtons(menu).find(button =>
+      getNativeMenuItemName(button) === itemName
+    );
+  }
+
+  function isDashboardAddWidgetMenu(menu) {
+    const itemNames = new Set(
+      getMenuButtons(menu)
+        .map(getNativeMenuItemName)
+        .filter(Boolean)
+    );
+    return ADD_WIDGET_MENU_KEYS.every(key => itemNames.has(key));
+  }
+
+  function removeClonedButtonState(button) {
+    [
+      'id',
+      'aria-controls',
+      'aria-describedby',
+      'aria-expanded',
+      'aria-labelledby',
+      'data-focused',
+      'data-focus-visible',
+      'data-hovered',
+      'data-pressed',
+      'disabled',
+    ].forEach(attr => button.removeAttribute(attr));
+  }
+
+  function bindMenuButtonInteractionState(button) {
+    const normalBackground = button.style.backgroundColor;
+    const normalColor = button.style.color;
+
+    function setHovered() {
+      button.setAttribute('data-hovered', '');
+      button.style.backgroundColor = MENU_ITEM_HOVER_BACKGROUND;
+      button.style.color = MENU_ITEM_HOVER_TEXT;
+    }
+
+    function clearHovered() {
+      button.removeAttribute('data-hovered');
+      button.removeAttribute('data-pressed');
+      button.style.backgroundColor = normalBackground;
+      button.style.color = normalColor;
+    }
+
+    function setPressed() {
+      button.setAttribute('data-pressed', '');
+    }
+
+    function clearPressed() {
+      button.removeAttribute('data-pressed');
+    }
+
+    button.addEventListener('pointerenter', setHovered);
+    button.addEventListener('pointerleave', clearHovered);
+    button.addEventListener('pointerdown', setPressed);
+    button.addEventListener('pointerup', clearPressed);
+    button.addEventListener('pointercancel', clearPressed);
+    button.addEventListener('focus', () => button.setAttribute('data-focused', ''));
+    button.addEventListener('blur', () => {
+      button.removeAttribute('data-focused');
+      clearHovered();
+    });
+    button.addEventListener('keydown', event => {
+      if (event.key === 'Enter' || event.key === ' ') setPressed();
+    });
+    button.addEventListener('keyup', clearPressed);
+  }
+
+  function createCustomMenuButton(templateButton, widgetDefinition, onSelect, logger) {
+    const button = templateButton.cloneNode(false);
+    removeClonedButtonState(button);
+    button.type = 'button';
+    button.dataset.abtCustomDashboardWidget = widgetDefinition.key;
+    button.replaceChildren();
+
+    const label = document.createElement('span');
+    label.textContent = widgetDefinition.label;
+    label.title = widgetDefinition.label;
+    button.appendChild(label);
+
+    const spacer = document.createElement('span');
+    spacer.style.flex = '1';
+    button.appendChild(spacer);
+
+    button.addEventListener('click', async event => {
+      event.preventDefault();
+      event.stopPropagation();
+      try {
+        await onSelect(widgetDefinition, button);
+      } catch (err) {
+        logger?.error?.('[ABT Dashboard Widgets] Failed to add custom widget:', err);
+      }
+    });
+    bindMenuButtonInteractionState(button);
+
+    return button;
+  }
+
+  function enhanceAddWidgetMenu({
+    widgetDefinitions,
+    onWidgetSelected,
+    dismissNativeMenu,
+    menuSelector = MENU_SELECTOR,
+    logger = console,
+  }) {
+    if (!Array.isArray(widgetDefinitions) || typeof onWidgetSelected !== 'function') {
+      return;
+    }
+
+    Array.from(document.querySelectorAll(menuSelector))
+      .filter(isDashboardAddWidgetMenu)
+      .forEach(menu => {
+        let anchor = getButtonByMenuItemName(menu, 'markdown-card');
+        if (!anchor) return;
+
+        widgetDefinitions.forEach(widgetDefinition => {
+          if (!widgetDefinition?.key || !widgetDefinition?.label) return;
+          if (menu.querySelector(`[${CUSTOM_WIDGET_ATTR}="${widgetDefinition.key}"]`)) return;
+
+          const button = createCustomMenuButton(
+            anchor,
+            widgetDefinition,
+            async (definition, menuButton) => {
+              dismissNativeMenu?.(menuButton);
+              await onWidgetSelected(definition);
+            },
+            logger
+          );
+
+          anchor.insertAdjacentElement('afterend', button);
+          anchor = button;
+        });
+      });
+  }
+
+  window[GLOBAL_NAME] = Object.freeze({
+    createMarkdownWidgetDefinition,
+    enhanceAddWidgetMenu,
+    getNativeMenuItemName,
+  });
+})();

--- a/public/content-scripts/income-breakdown-loader.js
+++ b/public/content-scripts/income-breakdown-loader.js
@@ -42,6 +42,7 @@
       injectStylesheet('css/income-breakdown.css');
       await injectScript('lib/d3.min.js');
       await injectScript('lib/d3-sankey.min.js');
+      await injectScript('content-scripts/dashboard-widget-utils.js');
       await injectScript('content-scripts/income-breakdown.js');
     } catch (err) {
       console.error('[ABT Income Breakdown] Failed to inject scripts:', err);

--- a/public/content-scripts/income-breakdown.js
+++ b/public/content-scripts/income-breakdown.js
@@ -12,6 +12,34 @@
   const NON_DRAGGABLE_CLASS = 'non-draggable-area';
   const POLL_INTERVAL = 1500;
   const DEBOUNCE_MS = 300;
+  const dashboardWidgetUtils = window.ActualBudgetTweaksDashboardWidgets;
+  const INCOME_BREAKDOWN_WIDGET = dashboardWidgetUtils?.createMarkdownWidgetDefinition?.({
+    key: 'income-breakdown',
+    label: DEFAULT_WIDGET_NAME,
+    placeholderText: PLACEHOLDER_TEXT,
+    width: DEFAULT_WIDGET_WIDTH,
+    height: DEFAULT_WIDGET_HEIGHT,
+  }) || {
+    key: 'income-breakdown',
+    label: DEFAULT_WIDGET_NAME,
+    matchesRecord(widget) {
+      const meta = parseMeta(widget?.meta);
+      return widget?.type === 'markdown-card' && String(meta.content || '').includes(PLACEHOLDER_TEXT);
+    },
+    buildWidgetPayload(dashboardPageId) {
+      return {
+        type: 'markdown-card',
+        width: DEFAULT_WIDGET_WIDTH,
+        height: DEFAULT_WIDGET_HEIGHT,
+        meta: {
+          content: PLACEHOLDER_TEXT,
+          name: DEFAULT_WIDGET_NAME,
+        },
+        dashboard_page_id: dashboardPageId,
+      };
+    },
+  };
+  const CUSTOM_DASHBOARD_WIDGETS = [INCOME_BREAKDOWN_WIDGET];
 
   // ── Settings persistence ──────────────────────────────────────────────
   function getSetting(key, defaultValue) {
@@ -159,8 +187,7 @@
   }
 
   function isIncomeBreakdownWidgetRecord(widget) {
-    const meta = parseMeta(widget?.meta);
-    return widget?.type === 'markdown-card' && String(meta.content || '').includes(PLACEHOLDER_TEXT);
+    return INCOME_BREAKDOWN_WIDGET.matchesRecord(widget);
   }
 
   function getWidgetName(widgetRecord) {
@@ -242,8 +269,7 @@
   }
 
   function isDashboardEditing() {
-    return Array.from(document.querySelectorAll('button'))
-      .some(btn => btn.textContent.trim() === 'Finish editing dashboard');
+    return Boolean(document.querySelector('.react-grid-item .hover-visible.non-draggable-area'));
   }
 
   function syncWidgetModeClasses() {
@@ -276,19 +302,13 @@
     });
   }
 
-  async function addIncomeBreakdownWidget() {
+  async function addCustomDashboardWidget(widgetDefinition) {
     const dashboardId = await getCurrentDashboardId();
     if (!dashboardId) return;
-    await sendDashboardMutation('dashboard-add-widget', {
-      type: 'markdown-card',
-      width: DEFAULT_WIDGET_WIDTH,
-      height: DEFAULT_WIDGET_HEIGHT,
-      meta: {
-        content: PLACEHOLDER_TEXT,
-        name: DEFAULT_WIDGET_NAME,
-      },
-      dashboard_page_id: dashboardId,
-    });
+    await sendDashboardMutation(
+      'dashboard-add-widget',
+      widgetDefinition.buildWidgetPayload(dashboardId)
+    );
   }
 
   function dismissNativeMenu(anchor) {
@@ -1282,37 +1302,12 @@
   }
 
   function enhanceAddWidgetMenu() {
-    const buttons = Array.from(document.querySelectorAll('button'));
-    const textWidgetButton = buttons.find(btn => btn.textContent.trim() === 'Text widget');
-    if (!textWidgetButton) return;
-
-    const menu = textWidgetButton.parentElement;
-    if (!menu || menu.querySelector('[data-abt-ib-add-widget]')) return;
-    const menuButtons = Array.from(menu.querySelectorAll('button'));
-    const hasAddWidgetItems = menuButtons.some(btn => btn.textContent.trim() === 'Cash flow graph') &&
-      menuButtons.some(btn => btn.textContent.trim() === 'Net worth graph');
-    if (!hasAddWidgetItems) return;
-
-    const incomeButton = textWidgetButton.cloneNode(true);
-    incomeButton.dataset.abtIbAddWidget = '1';
-    const textNode = Array.from(incomeButton.querySelectorAll('*'))
-      .find(el => el.textContent.trim() === 'Text widget');
-    if (textNode) {
-      textNode.textContent = DEFAULT_WIDGET_NAME;
-    } else {
-      incomeButton.textContent = DEFAULT_WIDGET_NAME;
-    }
-    incomeButton.addEventListener('click', async (e) => {
-      e.preventDefault();
-      e.stopPropagation();
-      try {
-        dismissNativeMenu(incomeButton);
-        await addIncomeBreakdownWidget();
-      } catch (err) {
-        console.error('[ABT Income Breakdown] Failed to add dashboard widget:', err);
-      }
+    dashboardWidgetUtils?.enhanceAddWidgetMenu?.({
+      widgetDefinitions: CUSTOM_DASHBOARD_WIDGETS,
+      onWidgetSelected: addCustomDashboardWidget,
+      dismissNativeMenu,
+      logger: console,
     });
-    textWidgetButton.insertAdjacentElement('afterend', incomeButton);
   }
 
   async function injectWidgets() {

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -52,6 +52,7 @@ export default defineConfig({
 					"content-scripts/content.css",
 					"lib/d3.min.js",
 					"lib/d3-sankey.min.js",
+					"content-scripts/dashboard-widget-utils.js",
 					"content-scripts/income-breakdown.js",
 					"content-scripts/category-template-insights.js",
 					"content-scripts/schedule-highlight.js",


### PR DESCRIPTION
## Changed

Small follow-up to #6 addressing the raised callouts (thank you @aelxxs for bringing them up). Extracts custom widget registration into a shared utility and adds better support for non-English languages.

The previous implementation in `income-breakdown.js` found the ‘Add Widget menu’ by matching English button texts like `Text widget`, `Cash flow graph`, and `Net worth graph`. Fixed the brittle plain text English matching by targeting React menu item keys and also fixed the missing interactive behaviors for our custom menu items. 

In summary:

- extract custom dashboard widget registration into `dashboard-widget-utils.js`
- register Income Breakdown through that shared utility
- target Actual’s Add Widget menu by native React menu item keys instead of finding English text
- fix missing native-like hover/pressed/focus behavior for the custom menu item

Future custom widgets can wire into the same seam by creating a widget definition with `createMarkdownWidgetDefinition(...)` and passing it to `enhanceAddWidgetMenu(...)`. 

This makes the injection more durable across non-English Actual users and provides a reusable path for adding more custom widgets later.

## Verification

- `node --check public/content-scripts/dashboard-widget-utils.js`
- `npm run check`
- `npm run build`
- `git diff --check`
- Manually verified the Add new widget menu still inserts Income Breakdown after switching Actual to Non-English