### PR TITLE
fix: unmount insights popover on close to prevent stacked schedule modals

### DIFF
--- a/src/features/workflows/category-template-insights/index.ts
+++ b/src/features/workflows/category-template-insights/index.ts
@@ -5,7 +5,8 @@ import { watchDom } from "@lib/utilities/dom-watcher";
 import { Page, matchesPage } from "@lib/utilities/pages";
 import { positionPopover } from "@lib/utilities/popover";
 import { getValue, setValue } from "@lib/utilities/store";
-import { mountToNode } from "@lib/utilities/svelte";
+import { mountToNodeWithReturn } from "@lib/utilities/svelte";
+import { unmount } from "svelte";
 import { getInsights, getProgressCents, invalidateCache, loadData, resetData } from "./data";
 import InsightsPopover from "./InsightsPopover.svelte";
 import type { CategoryInsight } from "./types";
@@ -271,6 +272,7 @@ let hoverTimer: ReturnType<typeof setTimeout> | null = null;
 let currentRow: HTMLElement | null = null;
 let currentCol: HTMLElement | null = null;
 let popoverWrap: HTMLElement | null = null;
+let popoverInstance: ReturnType<typeof mountToNodeWithReturn>["instance"] | null = null;
 
 function onColMouseEnter(e: Event) {
 	const col = e.currentTarget as HTMLElement;
@@ -307,7 +309,7 @@ async function openPopover(row: HTMLElement, anchor: HTMLElement) {
 	const progress = await getProgressCents(row, entry);
 	if (currentRow !== row) return;
 
-	const wrap = mountToNode(InsightsPopover, {
+	const { node: wrap, instance } = mountToNodeWithReturn(InsightsPopover, {
 		entry,
 		progress,
 		onClose: closePopover,
@@ -316,11 +318,16 @@ async function openPopover(row: HTMLElement, anchor: HTMLElement) {
 	wrap.style.display = "block";
 	document.body.appendChild(wrap);
 	popoverWrap = wrap;
+	popoverInstance = instance;
 
 	positionPopover(wrap, anchor, { gap: 6 });
 }
 
 function closePopover() {
+	if (popoverInstance) {
+		unmount(popoverInstance);
+		popoverInstance = null;
+	}
 	if (popoverWrap) {
 		popoverWrap.remove();
 		popoverWrap = null;


### PR DESCRIPTION
### Problem
With Category Template Insights enabled, pressing <kbd>F</kbd> on a hovered category navigates to Schedules correctly, but opens multiple schedule modals layered behind the intended one, causing one extra modal for each category popover that had been hovered earlier in the session.

### RCA
`closePopover()` only removed the popover's wrapper DOM node. The Svelte component itself was never unmounted (`mountToNode()` discards the mount instance), so the `keydown` listener registered via `<svelte:window>` stayed attached to `window`. Every hover leaked one listener, each holding its own captured schedule; pressing <kbd>F</kbd> fired all of them, and each one navigated and clicked its schedule row.

### Fix
Mount with `mountToNodeWithReturn()` and call `unmount(instance)` in `closePopover()`, the same pattern already used by `template-plan` and `category-emoji-picker`. Since the hotkey handler calls `onClose()` first, the listener is destroyed as soon as <kbd>F</kbd> is handled, so only one modal can open. This also fixes the same leak for the <kbd>Escape</kbd> handler.

### Testing
- `pnpm check` and `pnpm build` pass
- Manually: hover several categories on the budget page (letting each popover appear), then hover one with a linked schedule and press <kbd>F</kbd> — exactly one schedule modal opens