### PR TITLE
fix: resolve all svelte-check errors and warnings

### DIFF
--- a/src/features/appearance/category-color-dots/ColorPicker.svelte
+++ b/src/features/appearance/category-color-dots/ColorPicker.svelte
@@ -17,6 +17,7 @@
 				class="cp__swatch"
 				class:is-active={currentColor === color}
 				style="background: {color}"
+				aria-label="Select color {color}"
 				onclick={() => onSelect(color)}
 			></button>
 		{/each}

--- a/src/features/appearance/sidebar-shortcuts/components/Modal.svelte
+++ b/src/features/appearance/sidebar-shortcuts/components/Modal.svelte
@@ -168,8 +168,8 @@
 	}
 </script>
 
-<div class="overlay" role="presentation" onclick={onClose}>
-	<div class="modal" role="dialog" tabindex="-1" onclick={(e) => e.stopPropagation()}>
+<div class="overlay" role="presentation" onclick={(e) => e.target === e.currentTarget && onClose()}>
+	<div class="modal" role="dialog" tabindex="-1">
 		<div class="hd">
 			<h3>Shortcuts</h3>
 			<button class="close-btn" onclick={onClose}>✕</button>

--- a/src/features/appearance/sidebar-shortcuts/components/ToolPopover.svelte
+++ b/src/features/appearance/sidebar-shortcuts/components/ToolPopover.svelte
@@ -13,8 +13,8 @@
 	}>();
 </script>
 
-<div class="backdrop" role="presentation" onclick={onClose}>
-	<div class="popover" role="dialog" tabindex="-1" style="left: {anchorX}px; top: {anchorY}px" onclick={(e) => e.stopPropagation()}>
+<div class="backdrop" role="presentation" onclick={(e) => e.target === e.currentTarget && onClose()}>
+	<div class="popover" role="dialog" tabindex="-1" style="left: {anchorX}px; top: {anchorY}px">
 		<div class="popover__hd">
 			<span class="popover__title">{title}</span>
 			<button class="popover__close" onclick={onClose}>✕</button>

--- a/src/features/workflows/spending-calendar/Calendar.svelte
+++ b/src/features/workflows/spending-calendar/Calendar.svelte
@@ -360,7 +360,7 @@
 			<h2 class="cal-title">{monthNames[month]} {year}</h2>
 		</div>
 		<div class="cal-header__right">
-			<button class="cal-nav" onclick={prevMonth}>
+			<button class="cal-nav" aria-label="Previous month" onclick={prevMonth}>
 				<svg
 					width="16"
 					height="16"
@@ -373,7 +373,7 @@
 				>
 			</button>
 			<button class="cal-today" onclick={goToday} disabled={isAtCurrentMonth()}>Today</button>
-			<button class="cal-nav" onclick={nextMonth} disabled={isAtCurrentMonth()}>
+			<button class="cal-nav" aria-label="Next month" onclick={nextMonth} disabled={isAtCurrentMonth()}>
 				<svg
 					width="16"
 					height="16"
@@ -398,6 +398,7 @@
 
 			{#each days as day, idx}
 				{@const lastRow = days.length - 7}
+				<!-- svelte-ignore a11y_no_noninteractive_tabindex -- role="button" and tabindex are set by the same condition -->
 				<div
 					class="cal-cell"
 					class:is-today={day.isToday}

--- a/src/features/workflows/spending-calendar/DayDetail.svelte
+++ b/src/features/workflows/spending-calendar/DayDetail.svelte
@@ -3,10 +3,12 @@
 	import { fmtMoney } from "@lib/utilities/currency";
 	import type { DayTransaction } from "./types";
 
-	const { transactions } = $props<{
+	const {
+		transactions,
+	}: {
 		date: Date;
 		transactions: DayTransaction[];
-	}>();
+	} = $props();
 
 	function fmt(cents: number): string {
 		return fmtMoney(cents);


### PR DESCRIPTION
Gets `pnpm check` to a clean baseline: **2 errors and 6 warnings → 0/0**. No behavior changes.

- **DayDetail.svelte** — the two implicit-`any` errors: props were typed via the `$props<T>()` generic, which Svelte 5 doesn't use for inference, leaving `transactions` untyped. Moved the type onto the destructuring annotation.
- **ColorPicker.svelte / Calendar.svelte** — added `aria-label`s to icon-only buttons (color swatches, prev/next month nav).
- **Modal.svelte / ToolPopover.svelte** — the dialog `div` carried a click handler solely to `stopPropagation()`, triggering the "non-interactive element with click handler" warning. Replaced with an `e.target === e.currentTarget` check on the overlay; backdrop-click-to-close behavior is unchanged.
- **Calendar.svelte** — the "noninteractive element cannot have nonnegative tabIndex" warning on day cells is a false positive: `role="button"` and `tabindex={0}` are gated by the same condition, so the element is interactive whenever it's focusable. Suppressed with an explanatory `svelte-ignore`.

### Testing
- `pnpm check`: 0 errors, 0 warnings
- `pnpm build` passes