### PR TITLE
fix: spending calendar schedule transactions not dropping and recurrence in current month bug fixs

### DIFF
--- a/src/features/workflows/spending-calendar/Calendar.svelte
+++ b/src/features/workflows/spending-calendar/Calendar.svelte
@@ -125,6 +125,41 @@
 		return 0;
 	}
 
+	function isoDate(d: Date): string {
+		return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+	}
+
+	/**
+	 * Mirrors Actual's own paid-matching window (`getScheduleOccurrenceMatchStartDate`):
+	 * a manual schedule can be paid up to two days early, while an auto-posting or
+	 * fixed-date one always lands exactly on its date.
+	 */
+	function occurrenceMatchStart(s: Schedule, occurrenceDate: string): string {
+		if (s.posts_transaction || typeof s._date === "string") return occurrenceDate;
+		const d = new Date(`${occurrenceDate}T00:00:00`);
+		d.setDate(d.getDate() - 2);
+		return isoDate(d);
+	}
+
+	/**
+	 * Whether a past occurrence was eventually paid. Actual links a posted transaction
+	 * back to its schedule, so that link — not payee text — decides this. The month's
+	 * own transactions can't answer it alone: a bill paid late lands outside the month
+	 * being viewed, so this asks for anything linked at or after the match window.
+	 */
+	async function wasOccurrencePosted(s: Schedule, occurrenceDate: string): Promise<boolean> {
+		try {
+			const rows = await query<Transaction[]>("transactions", {
+				filter: { $and: [{ schedule: s.id }, { date: { $gte: occurrenceMatchStart(s, occurrenceDate) } }] },
+				select: ["id"],
+			});
+			return rows.length > 0;
+		} catch (e) {
+			console.warn("[ABT Calendar] could not check schedule posting", s.id, e);
+			return false;
+		}
+	}
+
 	/**
 	 * A schedule only carries `next_date` — its single next occurrence — so a month
 	 * further out would otherwise come up empty. Actual expands the recurrence rule
@@ -154,7 +189,7 @@
 	function dedupeTransactions(txs: DayTransaction[]): (DayTransaction & { count: number })[] {
 		const map = new Map<string, DayTransaction & { count: number }>();
 		for (const tx of txs) {
-			const key = `${tx.payee}|${tx.upcoming ? "u" : "r"}`;
+			const key = `${tx.payee}|${tx.upcoming ? "u" : tx.missed ? "m" : "r"}`;
 			const existing = map.get(key);
 			if (existing) {
 				existing.count++;
@@ -251,41 +286,62 @@
 			);
 
 			const monthPrefix = `${year}-${String(month + 1).padStart(2, "0")}-`;
-			const scheduleDays = new Map<string, Set<number>>();
-			for (const s of visibleSchedules) {
-				if (s.next_date?.startsWith(monthPrefix)) {
-					scheduleDays.set(s.id, new Set([Number(s.next_date.slice(-2))]));
-				}
+			const todayIso = isoDate(today);
+			const occurrences = new Map<string, Set<string>>();
+			function addOccurrence(id: string, date: string) {
+				const dates = occurrences.get(id) ?? new Set<string>();
+				dates.add(date);
+				occurrences.set(id, dates);
 			}
 
-			// `next_date` already covers the current month, so only a future month
-			// needs the recurrence expanded to reach occurrences beyond the next one.
+			// A `next_date` that has already passed is Actual's marker for a missed
+			// schedule — it stays parked there until the schedule is paid, completed,
+			// or deleted (the latter two are filtered out above).
+			for (const s of visibleSchedules) {
+				if (s.next_date?.startsWith(monthPrefix)) addOccurrence(s.id, s.next_date);
+			}
+
+			// `next_date` is only ever the *next* occurrence, so any month from the
+			// current one onward needs the recurrence expanded to find the rest. The
+			// expansion starts at today, so past days never gain projected entries.
 			const monthsAhead = monthsFromNow();
-			if (monthsAhead > 0) {
+			if (monthsAhead >= 0) {
 				const count = Math.min((monthsAhead + 1) * 31 + 1, 400);
 				await Promise.all(
 					visibleSchedules.map(async (s) => {
 						// A one-off schedule stores a plain date, not a recurrence to expand.
 						if (!s._date || typeof s._date === "string") return;
 						const dates = await loadUpcomingDates(s, count);
-						const days = scheduleDays.get(s.id) ?? new Set<number>();
 						for (const d of dates) {
-							if (d.startsWith(monthPrefix)) days.add(Number(d.slice(-2)));
+							if (d.startsWith(monthPrefix)) addOccurrence(s.id, d);
 						}
-						if (days.size) scheduleDays.set(s.id, days);
 					}),
 				);
 			}
 
+			// Drop past occurrences that were eventually paid, so a bill only reads as
+			// missed for as long as it actually is one.
+			const posted = new Set<string>();
+			await Promise.all(
+				visibleSchedules.flatMap((s) =>
+					Array.from(occurrences.get(s.id) ?? new Set<string>(), async (date) => {
+						if (date >= todayIso) return;
+						if (await wasOccurrencePosted(s, date)) posted.add(`${s.id}|${date}`);
+					}),
+				),
+			);
+
 			for (const s of visibleSchedules) {
-				const days = scheduleDays.get(s.id);
-				if (!days) continue;
+				const dates = occurrences.get(s.id);
+				if (!dates) continue;
 				const payeeName = s.name || (s._payee && payeeMap.get(s._payee)) || "Unknown";
-				for (const sd of days) {
+				for (const date of dates) {
+					if (posted.has(`${s.id}|${date}`)) continue;
+					const sd = Number(date.slice(-2));
 					if (!byDay.has(sd)) byDay.set(sd, []);
 					const existing = byDay.get(sd)!;
 					// Skip if a real transaction with the same payee already exists on this day
-					if (existing.some((t) => !t.upcoming && t.payee === payeeName)) continue;
+					if (existing.some((t) => !t.upcoming && !t.missed && t.payee === payeeName)) continue;
 					existing.push({
 						payee: payeeName,
 						amount: parseScheduleAmount(s._amount),
@@ -293,7 +349,7 @@
 						categoryName: "",
 						accountName: (s._account && accountMap.get(s._account)) || "",
 						notes: "",
-						upcoming: true,
+						...(date < todayIso ? { missed: true } : { upcoming: true }),
 					});
 				}
 			}
@@ -314,7 +370,7 @@
 			// Current month
 			for (let d = 1; d <= daysInMonth; d++) {
 				const txs = byDay.get(d) || [];
-				const total = txs.reduce((sum, t) => sum + t.amount, 0);
+				const total = txs.reduce((sum, t) => sum + (t.missed ? 0 : t.amount), 0);
 				grid.push({
 					date: d,
 					total,
@@ -372,7 +428,7 @@
 		cleanupPanel();
 
 		const date = new Date(year, month, day.date);
-		const total = day.transactions.reduce((s, t) => s + t.amount, 0);
+		const total = day.transactions.reduce((s, t) => s + (t.missed ? 0 : t.amount), 0);
 
 		headerContainer = document.createElement("div");
 		headerInstance = mount(DayHeader, {
@@ -538,12 +594,14 @@
 						{@const deduped = dedupeTransactions(day.transactions)}
 						<div class="cal-cell__txs">
 							{#each deduped.slice(0, 3) as tx}
-								<div class="cal-tx" class:is-upcoming={tx.upcoming}>
+								<div class="cal-tx" class:is-upcoming={tx.upcoming} class:is-missed={tx.missed}>
 									<span
 										class="cal-tx__dot"
 										style="background: {tx.upcoming
 											? 'var(--color-pageTextSubdued)'
-											: getCategoryColor(tx.categoryId)}"
+											: tx.missed
+												? 'var(--color-errorText)'
+												: getCategoryColor(tx.categoryId)}"
 									></span>
 									<span class="cal-tx__payee abt-privacy-number">{tx.payee}</span>
 									{#if tx.count > 1}
@@ -558,7 +616,7 @@
 
 						<div class="cal-cell__bars">
 							{#each Object.entries(day.transactions.reduce((acc, t) => {
-										if (t.amount < 0) {
+										if (!t.missed && t.amount < 0) {
 											acc[t.categoryId] = (acc[t.categoryId] || 0) + Math.abs(t.amount);
 										}
 										return acc;
@@ -885,6 +943,16 @@
 	.cal-tx.is-upcoming {
 		opacity: 0.45;
 		font-style: italic;
+	}
+
+	.cal-tx.is-missed {
+		opacity: 0.75;
+	}
+
+	.cal-tx.is-missed .cal-tx__payee {
+		color: var(--color-errorText);
+		text-decoration: line-through;
+		text-decoration-color: color-mix(in srgb, var(--color-errorText) 45%, transparent);
 	}
 
 	.cal-tx.is-upcoming .cal-tx__dot {

--- a/src/features/workflows/spending-calendar/DayDetail.svelte
+++ b/src/features/workflows/spending-calendar/DayDetail.svelte
@@ -21,7 +21,7 @@
 	const categoryBreakdown = $derived.by(() => {
 		const map = new Map<string, { name: string; amount: number; id: string }>();
 		for (const t of transactions) {
-			if (t.amount >= 0 || t.upcoming) continue;
+			if (t.amount >= 0 || t.upcoming || t.missed) continue;
 			const key = t.categoryId || "__uncategorized";
 			const existing = map.get(key);
 			if (existing) {
@@ -34,8 +34,9 @@
 	});
 
 	const totalSpent = $derived(categoryBreakdown.reduce((s, c) => s + c.amount, 0));
-	const actualTxs = $derived(transactions.filter((t) => !t.upcoming));
+	const actualTxs = $derived(transactions.filter((t) => !t.upcoming && !t.missed));
 	const upcomingTxs = $derived(transactions.filter((t) => t.upcoming));
+	const missedTxs = $derived(transactions.filter((t) => t.missed));
 </script>
 
 <div class="dd">
@@ -82,6 +83,27 @@
 						</div>
 						{#if tx.notes}
 							<div class="dd__tx-notes abt-privacy-number">{tx.notes}</div>
+						{/if}
+					</div>
+				{/each}
+			</div>
+		</div>
+	{/if}
+
+	{#if missedTxs.length > 0}
+		<div class="dd__section">
+			<div class="dd__section-title dd__section-title--missed">Missed</div>
+			<div class="dd__list">
+				{#each missedTxs as tx}
+					<div class="dd__tx dd__tx--missed">
+						<div class="dd__tx-row">
+							<span class="dd__tx-payee abt-privacy-number">{tx.payee}</span>
+							<span class="dd__tx-amount abt-privacy-number is-neg">{fmt(tx.amount)}</span>
+						</div>
+						{#if tx.accountName}
+							<div class="dd__tx-meta">
+								<span>{tx.accountName}</span>
+							</div>
 						{/if}
 					</div>
 				{/each}
@@ -254,4 +276,16 @@
 		opacity: 0.5;
 		font-style: italic;
 	}
+
+	/* ── Missed ── */
+	.dd__section-title--missed {
+		color: var(--color-errorText);
+	}
+
+	.dd__tx--missed .dd__tx-payee {
+		color: var(--color-errorText);
+		text-decoration: line-through;
+		text-decoration-color: color-mix(in srgb, var(--color-errorText) 45%, transparent);
+	}
+
 </style>

--- a/src/features/workflows/spending-calendar/types.ts
+++ b/src/features/workflows/spending-calendar/types.ts
@@ -5,5 +5,8 @@ export interface DayTransaction {
 	categoryId: string;
 	accountName: string;
 	notes: string;
+	/** A scheduled occurrence that hasn't happened yet. */
 	upcoming?: boolean;
+	/** A scheduled occurrence whose date has passed with no matching transaction. */
+	missed?: boolean;
 }

--- a/src/features/workflows/spending-calendar/types.ts
+++ b/src/features/workflows/spending-calendar/types.ts
@@ -5,8 +5,6 @@ export interface DayTransaction {
 	categoryId: string;
 	accountName: string;
 	notes: string;
-	/** A scheduled occurrence that hasn't happened yet. */
 	upcoming?: boolean;
-	/** A scheduled occurrence whose date has passed with no matching transaction. */
 	missed?: boolean;
 }


### PR DESCRIPTION
Bug fixes for the previous spending calendar enhancement. 

A schedule whose date had passed unpaid remained on the spending calendar even when the transaction had posted properly. 
It now properly clears from the spending calendar when the transaction posts (matched on Actual's `transaction.schedule` link, so late payments count), or when the schedule is deleted.

Recurrence expansion now covers the current month too, not just future ones.
Previously, the current month showed only the next occurrence per schedule, while next month showed all of them.

Verified and Tested. 

Before Picture:
(See arrows for what transactions link to what schedule)
<img width="441" height="440" alt="image" src="https://github.com/user-attachments/assets/631b8b92-f188-43d7-9d2d-e9687c19088f" />

New Picture:
(Created a new missed transaction to show how it displays until the transaction posts)
<img width="359" height="379" alt="image" src="https://github.com/user-attachments/assets/2afec5ce-0254-47ec-97b0-5eb16de73ea6" />
