### PR TITLE
feat(theme): add "Actual default" native theme option

### DIFF
--- a/src/features/layout/background-pattern/Picker.svelte
+++ b/src/features/layout/background-pattern/Picker.svelte
@@ -71,7 +71,7 @@
 
 	.bpp-swatch {
 		height: 52px;
-		background-color: var(--ctp-crust);
+		background-color: var(--ctp-crust, var(--color-pageBackground));
 	}
 
 	.bpp-label {

--- a/src/features/layout/background-pattern/data.ts
+++ b/src/features/layout/background-pattern/data.ts
@@ -1,12 +1,12 @@
 export const bgPatterns: Record<string, string> = {
 	"Polka Dots":
-		"background-color: var(--ctp-crust); background-image: radial-gradient(var(--ctp-surface0) 0.5px, var(--ctp-crust) 0.5px); background-size: 10px 10px;",
+		"background-color: var(--ctp-crust, var(--color-pageBackground)); background-image: radial-gradient(var(--ctp-surface0, var(--color-tableBorder)) 0.5px, var(--ctp-crust, var(--color-pageBackground)) 0.5px); background-size: 10px 10px;",
 	"Polka Dots 2":
-		"background-color: var(--ctp-crust); background-image: radial-gradient(var(--ctp-surface0) 0.5px, transparent 0.5px), radial-gradient(var(--ctp-surface0) 0.5px, var(--ctp-crust) 0.5px); background-size: 20px 20px; background-position: 0 0, 10px 10px;",
+		"background-color: var(--ctp-crust, var(--color-pageBackground)); background-image: radial-gradient(var(--ctp-surface0, var(--color-tableBorder)) 0.5px, transparent 0.5px), radial-gradient(var(--ctp-surface0, var(--color-tableBorder)) 0.5px, var(--ctp-crust, var(--color-pageBackground)) 0.5px); background-size: 20px 20px; background-position: 0 0, 10px 10px;",
 	"Diagonal Stripes":
-		"background-color: var(--ctp-crust); background-size: 10px 10px; background-image: repeating-linear-gradient(45deg, var(--ctp-surface0) 0, var(--ctp-surface0) 1px, var(--ctp-crust) 0, var(--ctp-crust) 50%);",
+		"background-color: var(--ctp-crust, var(--color-pageBackground)); background-size: 10px 10px; background-image: repeating-linear-gradient(45deg, var(--ctp-surface0, var(--color-tableBorder)) 0, var(--ctp-surface0, var(--color-tableBorder)) 1px, var(--ctp-crust, var(--color-pageBackground)) 0, var(--ctp-crust, var(--color-pageBackground)) 50%);",
 	Cross:
-		"background-color: var(--ctp-crust); background: radial-gradient(circle, transparent 20%, var(--ctp-crust) 20%, var(--ctp-crust) 80%, transparent 80%, transparent), radial-gradient(circle, transparent 20%, var(--ctp-crust) 20%, var(--ctp-crust) 80%, transparent 80%, transparent) 25px 25px, linear-gradient(var(--ctp-surface0) 2px, transparent 2px) 0 -1px, linear-gradient(90deg, var(--ctp-surface0) 2px, var(--ctp-crust) 2px) -1px 0; background-size: 50px 50px, 50px 50px, 25px 25px, 25px 25px;",
+		"background-color: var(--ctp-crust, var(--color-pageBackground)); background: radial-gradient(circle, transparent 20%, var(--ctp-crust, var(--color-pageBackground)) 20%, var(--ctp-crust, var(--color-pageBackground)) 80%, transparent 80%, transparent), radial-gradient(circle, transparent 20%, var(--ctp-crust, var(--color-pageBackground)) 20%, var(--ctp-crust, var(--color-pageBackground)) 80%, transparent 80%, transparent) 25px 25px, linear-gradient(var(--ctp-surface0, var(--color-tableBorder)) 2px, transparent 2px) 0 -1px, linear-gradient(90deg, var(--ctp-surface0, var(--color-tableBorder)) 2px, var(--ctp-crust, var(--color-pageBackground)) 2px) -1px 0; background-size: 50px 50px, 50px 50px, 25px 25px, 25px 25px;",
 	None: "background: var(--color-pageBackground);",
 };
 

--- a/src/features/layout/report-widget-background-color.ts
+++ b/src/features/layout/report-widget-background-color.ts
@@ -16,7 +16,7 @@ export const reportWidgetBackgroundColor = defineSetting({
 			width: 100%;
 			height: 100%;
 			transition: box-shadow 0.25s;
-			background-color: var(--ctp-crust);
+			background-color: var(--ctp-crust, var(--color-pageBackground));
 		}
 	`,
 });

--- a/src/features/layout/sidebar-account-spacing/index.ts
+++ b/src/features/layout/sidebar-account-spacing/index.ts
@@ -14,7 +14,7 @@ export const sidebarAccountSpacing = defineSetting({
 		css: (value: string) => `
 	        /* sidebar -- section title */
 	        .css-hfi7l9 {
-	            border-bottom: 2.5px solid var(--ctp-blue);
+	            border-bottom: 2.5px solid var(--ctp-blue, var(--color-pageTextLink));
 	            padding-bottom: ${value};
 	        }
 

--- a/src/features/readability/color-transactions.ts
+++ b/src/features/readability/color-transactions.ts
@@ -11,10 +11,11 @@ function colorUpcomingRows() {
 			const account = row.querySelector<HTMLElement>('*[data-testid="account"]');
 			const payee = row.querySelector<HTMLElement>('*[data-testid="payee"]');
 			const notes = row.querySelector<HTMLElement>('*[data-testid="notes"]');
-			if (date) date.style.color = "var(--ctp-peach)";
-			if (account) account.style.color = "var(--ctp-peach)";
-			if (payee) payee.style.color = "var(--ctp-peach)";
-			if (notes) notes.style.color = "var(--ctp-peach)";
+			const upcoming = "var(--ctp-peach, var(--color-warningText))";
+			if (date) date.style.color = upcoming;
+			if (account) account.style.color = upcoming;
+			if (payee) payee.style.color = upcoming;
+			if (notes) notes.style.color = upcoming;
 		}
 	});
 }

--- a/src/features/theme/ThemeColorEditor.svelte
+++ b/src/features/theme/ThemeColorEditor.svelte
@@ -2,6 +2,7 @@
 	import { getValue, setValue } from "@lib/utilities/store";
 	import ColorRow from "./ColorRow.svelte";
 	import { editorState, type ThemeOverrides } from "./editor-state.svelte";
+	import { setRootProperty } from "./theme-apply";
 
 	type ColorKeys = Record<string, string>;
 
@@ -395,7 +396,7 @@
 		const root = document.querySelector<HTMLElement>(":root");
 		if (!root) return;
 		for (const [key, val] of Object.entries(keys)) {
-			root.style.setProperty(key, val);
+			setRootProperty(root, key, val);
 		}
 	}
 

--- a/src/features/theme/ThemeCreator.svelte
+++ b/src/features/theme/ThemeCreator.svelte
@@ -4,7 +4,7 @@
 	import { applyGlobalCSS } from "@lib/utilities/dom";
 	import { onMount } from "svelte";
 	import ColorRow from "./ColorRow.svelte";
-	import { BUILTIN_CSS, TOKENS_STYLE_ID } from "./theme-apply";
+	import { BUILTIN_CSS, setRootProperty, TOKENS_STYLE_ID } from "./theme-apply";
 
 	type Tab = "palette" | "css";
 
@@ -84,7 +84,7 @@
 		colors[key] = value;
 		const root = document.querySelector<HTMLElement>(":root");
 		if (root) {
-			root.style.setProperty(key, value);
+			setRootProperty(root, key, value);
 		}
 		applyGlobalCSS(BUILTIN_CSS, TOKENS_STYLE_ID);
 		onPaletteChange({ ...colors });
@@ -149,7 +149,7 @@
 		const root = document.querySelector<HTMLElement>(":root");
 		if (root) {
 			for (const [key, val] of Object.entries(newColors)) {
-				root.style.setProperty(key, val);
+				setRootProperty(root, key, val);
 			}
 		}
 		applyGlobalCSS(BUILTIN_CSS, TOKENS_STYLE_ID);

--- a/src/features/theme/ThemeCustomizer.svelte
+++ b/src/features/theme/ThemeCustomizer.svelte
@@ -14,6 +14,7 @@
 		fetchCommunityThemeCatalog,
 		getBuiltinPreviewColors,
 		isCommunityTheme,
+		NATIVE_THEME_KEY,
 		type RemoteTheme,
 	} from "./theme-apply";
 	import ThemeColorEditor from "./ThemeColorEditor.svelte";
@@ -60,6 +61,7 @@
 	onDestroy(() => mql.removeEventListener("change", onSchemeChange));
 
 	function getThemeName(key: string): string {
+		if (key === NATIVE_THEME_KEY) return "Actual default";
 		if (themes[key]) return themes[key].name;
 		if (isUserTheme(key)) return userThemeState.themes[key]?.name ?? key;
 		if (isCommunityTheme(key)) {
@@ -179,6 +181,11 @@
 			return matchesSearch && matchesCreator && matchesThemeType;
 		}),
 	);
+	const showNative = $derived(
+		(!q || "actual default native no theme".includes(q)) &&
+			themeFilter === "all" &&
+			(creatorFilter === "all" || creatorFilter === "ABT"),
+	);
 
 	const filteredCommunity = $derived(
 		remoteThemes.filter((theme) => {
@@ -198,7 +205,7 @@
 	]);
 
 	const isEmpty = $derived(
-		filteredBuiltin.length === 0 && filteredCommunity.length === 0 && !loadingRemote,
+		!showNative && filteredBuiltin.length === 0 && filteredCommunity.length === 0 && !loadingRemote,
 	);
 
 	let creatorNode: Node | null = null;
@@ -523,10 +530,29 @@
 				</div>
 			{/if}
 
-			{#if filteredBuiltin.length > 0}
+			{#if showNative || filteredBuiltin.length > 0}
 				<div class="gallery__section">
 					<div class="gallery__section-label">Built-in</div>
 					<div class="gallery__grid">
+						{#if showNative}
+							<button
+								class="card"
+								class:card--active={activeThemeKey === NATIVE_THEME_KEY}
+								onclick={() => selectTheme(NATIVE_THEME_KEY)}
+								title="Use Actual Budget's default theme"
+							>
+								<div class="card__swatches card__swatches--placeholder">
+									<div class="swatch" style="background: var(--color-pageBackground);"></div>
+								</div>
+								<div class="card__body">
+									<div class="card__name">Actual default</div>
+									<div class="card__meta"><span class="card__source">No theme</span></div>
+								</div>
+								{#if activeThemeKey === NATIVE_THEME_KEY}
+									<div class="card__check" aria-label="Active theme">✓</div>
+								{/if}
+							</button>
+						{/if}
 						{#each filteredBuiltin as [key, theme]}
 							{@const previewColors = getBuiltinPreviewColors(key)}
 							{@const isActive = activeThemeKey === key}

--- a/src/features/theme/theme-apply.ts
+++ b/src/features/theme/theme-apply.ts
@@ -11,6 +11,19 @@ export type RemoteTheme = {
 };
 
 export const TOKENS_STYLE_ID = "color-tokens";
+export const NATIVE_THEME_KEY = "native";
+
+const originalRootProperties = new Map<string, { value: string; priority: string }>();
+
+export function setRootProperty(root: HTMLElement, name: string, value: string) {
+	if (!originalRootProperties.has(name)) {
+		originalRootProperties.set(name, {
+			value: root.style.getPropertyValue(name),
+			priority: root.style.getPropertyPriority(name),
+		});
+	}
+	root.style.setProperty(name, value);
+}
 
 export const BUILTIN_CSS = `:root {
 	/* Budget */
@@ -308,7 +321,7 @@ export function applyUserPaletteTheme(id: string, keys: Record<string, string>) 
 	const root = document.querySelector<HTMLElement>(":root");
 	if (!root) return;
 	for (const [varName, val] of Object.entries(keys)) {
-		root.style.setProperty(varName, val);
+		setRootProperty(root, varName, val);
 	}
 	applyGlobalCSS(BUILTIN_CSS, TOKENS_STYLE_ID);
 	editorState.activeTheme = id;
@@ -333,7 +346,7 @@ export function applyOverrides(key: string) {
 	const root = document.querySelector<HTMLElement>(":root");
 	if (!root) return;
 	for (const [prop, val] of Object.entries(overrides)) {
-		root.style.setProperty(prop, val);
+		setRootProperty(root, prop, val);
 	}
 }
 
@@ -343,7 +356,7 @@ export function applyPalette(name: string) {
 	const root = document.querySelector<HTMLElement>(":root");
 	if (!root) return;
 	for (const [varName, val] of Object.entries(palette.keys)) {
-		root.style.setProperty(varName, val);
+		setRootProperty(root, varName, val);
 	}
 	applyGlobalCSS(BUILTIN_CSS, TOKENS_STYLE_ID);
 	editorState.activeTheme = name;
@@ -400,8 +413,27 @@ export async function applyCommunityTheme(repo: string) {
 	applyOverrides(repo);
 }
 
+export function applyNativeTheme() {
+	applyGlobalCSS("", TOKENS_STYLE_ID);
+	const root = document.querySelector<HTMLElement>(":root");
+	if (root) {
+		for (const [prop, original] of originalRootProperties) {
+			if (original.value) {
+				root.style.setProperty(prop, original.value, original.priority);
+			} else {
+				root.style.removeProperty(prop);
+			}
+		}
+	}
+	originalRootProperties.clear();
+	editorState.activeTheme = NATIVE_THEME_KEY;
+	applyOverrides(NATIVE_THEME_KEY);
+}
+
 export async function applyThemeByKey(key: string, fallback: string) {
-	if (isUserTheme(key)) {
+	if (key === NATIVE_THEME_KEY) {
+		applyNativeTheme();
+	} else if (isUserTheme(key)) {
 		const userTheme = userThemeState.themes[key];
 		if (userTheme) {
 			if (userTheme.type === "palette" && userTheme.keys) {

--- a/src/features/theme/themeLoader.ts
+++ b/src/features/theme/themeLoader.ts
@@ -1,6 +1,7 @@
 import { defineSetting } from "@features/types";
 import { getValue as getVal, getValue } from "@lib/utilities/store";
 import { editorState, type ThemeOverrides } from "./editor-state.svelte";
+import { applyOverrides } from "./theme-apply";
 
 export const themeLoader = defineSetting({
 	type: "custom",
@@ -16,23 +17,14 @@ export const themeLoader = defineSetting({
 
 		// Detect and handle old flat format (keys start with "--color-")
 		const firstKey = Object.keys(stored)[0];
-		const overrides: Record<string, string> = firstKey?.startsWith("--")
-			? (stored as Record<string, string>)
-			: ((stored as ThemeOverrides)[activeTheme] ?? {});
 
-		if (Object.keys(overrides).length === 0) return;
-
-		const root = document.querySelector<HTMLElement>(":root");
-		if (!root) return;
-		for (const [key, val] of Object.entries(overrides)) {
-			root.style.setProperty(key, val);
-		}
-
-		// Populate shared state so ThemeCustomizer can show indicators immediately
+		// Populate shared state for every theme, not just the active one, so switching
+		// themes in-session still re-applies that theme's saved overrides
 		const normalized: ThemeOverrides = firstKey?.startsWith("--")
 			? { [activeTheme]: stored as Record<string, string> }
 			: (stored as ThemeOverrides);
 		editorState.overrides = normalized;
 		editorState.activeTheme = activeTheme;
+		applyOverrides(activeTheme);
 	},
 });

--- a/src/features/workflows/sidebar/components/CommandPalette.svelte
+++ b/src/features/workflows/sidebar/components/CommandPalette.svelte
@@ -6,6 +6,7 @@
 		applyThemeByKey,
 		fetchCommunityThemeCatalog,
 		getBuiltinPreviewColors,
+		NATIVE_THEME_KEY,
 		type RemoteTheme,
 	} from "@features/theme/theme-apply";
 	import { closeCalendar, isCalendarOpen } from "@features/workflows/spending-calendar";
@@ -197,14 +198,19 @@
 				: [];
 		}
 		if (page === "themes") {
-			const builtinItems: PaletteItem[] = Object.entries(themes)
-				.filter(([, t]) => match(t.name))
-				.map(([key, t]) => ({
-					kind: "theme" as const,
-					key,
-					name: t.name,
-					swatch: getBuiltinPreviewColors(key),
-				}));
+			const builtinItems: PaletteItem[] = [
+				...(match("Actual default")
+					? [{ kind: "theme" as const, key: NATIVE_THEME_KEY, name: "Actual default", swatch: [] }]
+					: []),
+				...Object.entries(themes)
+					.filter(([, t]) => match(t.name))
+					.map(([key, t]) => ({
+						kind: "theme" as const,
+						key,
+						name: t.name,
+						swatch: getBuiltinPreviewColors(key),
+					})),
+			];
 			const communityItems: PaletteItem[] = communityThemes
 				.filter((t) => match(t.name))
 				.map((t) => ({ kind: "theme" as const, key: t.repo, name: t.name, swatch: t.colors }));


### PR DESCRIPTION
Adds a NATIVE_THEME_KEY theme that removes ABT's injected color tokens and restores Actual Budget's own theme, selectable from the theme gallery and the command palette.

- Track every :root custom property ABT sets so switching to native can restore or remove it, including live color-editor and theme-creator writes
- Apply saved per-theme overrides on native like any other theme key, and populate override state for all themes on load so switching themes in-session re-applies that theme's saved colors
- Give the --ctp-* references in background-pattern, sidebar-account-spacing, report-widget-background-color and color-transactions --color-* fallbacks so those tweaks still render under the native theme

## What does this change?

Allows you to use the ATB features/tweaks without having to change from the default theme

<img width="476" height="386" alt="image" src="https://github.com/user-attachments/assets/80e43a15-fa24-430b-9846-9c33ecb85b54" />

## Checklist

- [x] Tested against a real Actual Budget instance
- [x] `pnpm format && pnpm check && pnpm lint` pass locally
- [x] Toggling the setting off leaves no listeners/DOM nodes/observers behind
- [x] `label`/`description`/`icon`/`group` are set, and are plain string literals (not computed — see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Screenshot or short clip attached, for anything visually observable
